### PR TITLE
fix(common): disable more fenced codeblock rules

### DIFF
--- a/src/configs/common/index.js
+++ b/src/configs/common/index.js
@@ -13,10 +13,12 @@ module.exports = {
       parserOptions: {
         impliedStrict: true,
       },
-      //  These rules cannot be satisfied by fenced code blocks as they are
-      //  effectively partial JavaScript files.
+      // These rules just don't make sense when checking what is, effectively,
+      // part of a file
       rules: {
         'eol-last': 'off',
+        'no-undef': 'off',
+        'require-jsdoc': 'off',
         strict: 'off',
         'unicode-bom': 'off',
       },


### PR DESCRIPTION
no-undef and require-jsdoc just don't make sense in markdown files