### PR TITLE
fixes

### DIFF
--- a/src/configs/common/index.js
+++ b/src/configs/common/index.js
@@ -9,7 +9,11 @@ module.exports = {
   overrides: [
     // Apply lint to fenced JavaScript code blocks in markdown files.
     {
-      files: ['**/*.md'],
+      files: [
+        '**/*.md',
+        // need the trailing /** to pick up code blocks in markdown files
+        '**/*.md/**',
+      ],
       parserOptions: {
         impliedStrict: true,
       },

--- a/src/configs/typescript/index.js
+++ b/src/configs/typescript/index.js
@@ -108,5 +108,13 @@ module.exports = {
         'valid-jsdoc': 'off',
       },
     },
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        // <T extends unknown> is necessary in TSX files to prove it's a
+        // generic and not a component
+        '@typescript-eslint/no-unnecessary-type-constraint': 'off',
+      },
+    },
   ],
 };


### PR DESCRIPTION
- fix(common): make sure markdown overrides apply to codeblocks
- fix(typescript): disable rule that is not valid in tsx files
